### PR TITLE
Pass parameter vectors by reference

### DIFF
--- a/examples/LineModel.hpp
+++ b/examples/LineModel.hpp
@@ -49,12 +49,12 @@ protected:
     };
 
 public:
-    Line2DModel(std::vector<std::shared_ptr<GRANSAC::AbstractParameter>> InputParams)
+    Line2DModel(const std::vector<std::shared_ptr<GRANSAC::AbstractParameter>> &InputParams)
     {
 	Initialize(InputParams);
     };
 
-    virtual void Initialize(std::vector<std::shared_ptr<GRANSAC::AbstractParameter>> InputParams) override
+    virtual void Initialize(const std::vector<std::shared_ptr<GRANSAC::AbstractParameter>> &InputParams) override
     {
 	if(InputParams.size() != 2)
 	    throw std::runtime_error("Line2DModel - Number of input parameters does not match minimum number required for this model.");
@@ -80,7 +80,7 @@ public:
 	m_DistDenominator = sqrt(m_a * m_a + m_b * m_b); // Cache square root for efficiency
     };
 
-    virtual std::pair<GRANSAC::VPFloat, std::vector<std::shared_ptr<GRANSAC::AbstractParameter>>> Evaluate(std::vector<std::shared_ptr<GRANSAC::AbstractParameter>> EvaluateParams, GRANSAC::VPFloat Threshold)
+    virtual std::pair<GRANSAC::VPFloat, std::vector<std::shared_ptr<GRANSAC::AbstractParameter>>> Evaluate(const std::vector<std::shared_ptr<GRANSAC::AbstractParameter>> &EvaluateParams, GRANSAC::VPFloat Threshold)
     {
 	std::vector<std::shared_ptr<GRANSAC::AbstractParameter>> Inliers;
 	int nTotalParams = EvaluateParams.size();

--- a/include/AbstractModel.hpp
+++ b/include/AbstractModel.hpp
@@ -25,12 +25,12 @@ namespace GRANSAC
     protected:
 	std::array<std::shared_ptr<AbstractParameter>, t_NumParams> m_MinModelParams;
 
-	virtual VPFloat ComputeDistanceMeasure(std::shared_ptr<AbstractParameter> Param) = 0;
+        virtual VPFloat ComputeDistanceMeasure(std::shared_ptr<AbstractParameter> Param) = 0;
 
     public:
-	virtual void Initialize(std::vector<std::shared_ptr<AbstractParameter>> InputParams) = 0;
-	virtual std::pair<VPFloat, std::vector<std::shared_ptr<AbstractParameter>>> Evaluate(std::vector<std::shared_ptr<AbstractParameter>> EvaluateParams, VPFloat Threshold) = 0;
+        virtual void Initialize(const std::vector<std::shared_ptr<AbstractParameter>> &InputParams) = 0;
+        virtual std::pair<VPFloat, std::vector<std::shared_ptr<AbstractParameter>>> Evaluate(const std::vector<std::shared_ptr<AbstractParameter>> &EvaluateParams, VPFloat Threshold) = 0;
 
-	virtual std::array<std::shared_ptr<AbstractParameter>, t_NumParams> GetModelParams(void) { return m_MinModelParams; };
+        virtual std::array<std::shared_ptr<AbstractParameter>, t_NumParams> GetModelParams(void) { return m_MinModelParams; };
     };
 } // namespace GRANSAC

--- a/include/GRANSAC.hpp
+++ b/include/GRANSAC.hpp
@@ -35,7 +35,7 @@ namespace GRANSAC
 	RANSAC(void)
         {
 	    int nThreads = std::max(1, omp_get_max_threads());
-            std::cout << "[ INFO ]: Maximum usable threads: " << nThreads << std::endl;
+            std::cerr << "[ INFO ]: Maximum usable threads: " << nThreads << std::endl;
 	    for(int i = 0; i < nThreads; ++i)
 	    {
 		std::random_device SeedDevice;
@@ -70,7 +70,7 @@ namespace GRANSAC
 	{
 	    if(Data.size() <= t_NumParams)
 	    {
-                std::cout << "[ WARN ]: RANSAC - Number of data points is too less. Not doing anything." << std::endl;
+                std::cerr << "[ WARN ]: RANSAC - Number of data points is too less. Not doing anything." << std::endl;
 		return false;
 	    }
 
@@ -118,7 +118,7 @@ namespace GRANSAC
 		}
 	    }
 
-            // std::cout << "BestInlierFraction: " << m_BestModelScore << std::endl;
+            // std::cerr << "BestInlierFraction: " << m_BestModelScore << std::endl;
 
 	    Reset();
 

--- a/include/GRANSAC.hpp
+++ b/include/GRANSAC.hpp
@@ -33,9 +33,9 @@ namespace GRANSAC
 
     public:
 	RANSAC(void)
-	{
+        {
 	    int nThreads = std::max(1, omp_get_max_threads());
-	    std::cout << "[ INFO ]: Maximum usable threads: " << nThreads << std::endl;
+            std::cout << "[ INFO ]: Maximum usable threads: " << nThreads << std::endl;
 	    for(int i = 0; i < nThreads; ++i)
 	    {
 		std::random_device SeedDevice;
@@ -66,11 +66,11 @@ namespace GRANSAC
 	std::shared_ptr<T> GetBestModel(void) { return m_BestModel; };
 	const std::vector<std::shared_ptr<AbstractParameter>>& GetBestInliers(void) { return m_BestInliers; };
 
-	bool Estimate(std::vector<std::shared_ptr<AbstractParameter>> Data)
+        bool Estimate(const std::vector<std::shared_ptr<AbstractParameter>> &Data)
 	{
 	    if(Data.size() <= t_NumParams)
 	    {
-		std::cout << "[ WARN ]: RANSAC - Number of data points is too less. Not doing anything." << std::endl;
+                std::cout << "[ WARN ]: RANSAC - Number of data points is too less. Not doing anything." << std::endl;
 		return false;
 	    }
 
@@ -118,7 +118,7 @@ namespace GRANSAC
 		}
 	    }
 
-	    // std::cout << "BestInlierFraction: " << m_BestModelScore << std::endl;
+            // std::cout << "BestInlierFraction: " << m_BestModelScore << std::endl;
 
 	    Reset();
 


### PR DESCRIPTION
Hi! Thanks for the library, I found it quite useful when working on my Bachelor thesis. I had to intersect >2 noisy lines in a single point, and GRANSAC provided an easy way to test whether a RANSAC-like solution works in my problem (and yes, it does).

However, I noticed a significant performance drop when using RANSAC. I'm trying to fit a large number of objects (up to 4000) on every frame of a 30fps video. Upon profiling the program, I found out that we can improve by passing the parameters are passed by reference rather than by value, so that it doesn't copy 4000 shared_ptr's every time. It helped a bit, and I think there's no good reason for copying those vectors anyway. This PR in a nutshell:

```
void GRANSAC::SomeMethod(vector<AbstractParameterPtr> params)        // old
void GRANSAC::SomeMethod(const vector<AbstractParameterPtr> &params) // new
```

I also made the library to output messages to stderr instead of stdout. Stdout is really for the program's output data, and library warnings do not belong there.

Cheers!